### PR TITLE
added censor variable + extracted km cohort

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -11,13 +11,13 @@ from ehrql import codelist_from_csv
 
 # Ethnicity
 
-ethnicity_codelist5 = codelist_from_csv(
+ethnicity5 = codelist_from_csv(
   "codelists/opensafely-ethnicity-snomed-0removed.csv",
   column="code",
   category_column="Label_6", # it's 6 because there is an additional "6 - Not stated" but this is not represented in SNOMED, instead corresponding to no ethnicity code
 )
 
-ethnicity_codelist16 = codelist_from_csv(
+ethnicity16 = codelist_from_csv(
   "codelists/opensafely-ethnicity-snomed-0removed.csv",
   column="code",
   category_column="Label_16",

--- a/analysis/dataset_definition_fixed.py
+++ b/analysis/dataset_definition_fixed.py
@@ -27,7 +27,7 @@ from ehrql.tables.tpp import (
   ons_deaths
 )
 # import codelists
-from codelists import *
+import codelists
 
 study_dates = loads(
     Path("lib/dates.json").read_text(),
@@ -79,17 +79,18 @@ dataset.sex = patients.sex
 # rather than as known/recorded on the vaccination date, even though this looks into the future.
 
 ethnicity = (clinical_events
-  .where(clinical_events.snomedct_code.is_in(ethnicity_codelist16))
+  .where(clinical_events.snomedct_code.is_in(codelists.ethnicity16))
   .sort_by(clinical_events.date)
   .where(clinical_events.date.is_on_or_before(end_date))
   .last_for_patient()
 )
+
 # 
 # # ethnicity using 5 groups + unknown
-dataset.ethnicity5 = ethnicity.snomedct_code.to_category(ethnicity_codelist5)
+dataset.ethnicity5 = ethnicity.snomedct_code.to_category(codelists.ethnicity5)
 # 
 # # ethnicity using 16 groups + unknown
-dataset.ethnicity16 = ethnicity.snomedct_code.to_category(ethnicity_codelist16)
+dataset.ethnicity16 = ethnicity.snomedct_code.to_category(codelists.ethnicity16)
 
 # patient death date
 dataset.death_date = ons_deaths.date

--- a/analysis/dataset_definition_snapshot.py
+++ b/analysis/dataset_definition_snapshot.py
@@ -12,6 +12,7 @@ from sys import argv
 from datetime import datetime
 
 from ehrql import (
+    show,
     case,
     create_dataset,
     days,
@@ -64,13 +65,4 @@ primis_variables(dataset = dataset, index_date = snapshot_date)
 # other_cx_variables(dataset = dataset, index_date = snapshot_date)
 
 # Deregistration dates after the snapshot date
-dereg_date = (
-    practice_registrations
-    .where(practice_registrations.end_date.is_not_null())
-    .where(practice_registrations.end_date.is_on_or_after(snapshot_date))
-    .sort_by(practice_registrations.end_date)
-    .first_for_patient()
-    .end_date
-)
-# Add deregistration to dataset
-dataset.add_column(f"dereg_date", dereg_date)
+dataset.dereg_date = registered_patients.end_date

--- a/analysis/dataset_definition_snapshot.py
+++ b/analysis/dataset_definition_snapshot.py
@@ -25,9 +25,6 @@ from ehrql.tables.tpp import (
   ons_deaths,
 )
 
-# import codelists
-from codelists import *
-
 from analysis.variables_function import *
 
 study_dates = loads(

--- a/analysis/dataset_definition_snapshot.py
+++ b/analysis/dataset_definition_snapshot.py
@@ -65,3 +65,15 @@ dataset.define_population(
 demographic_variables(dataset = dataset, index_date = snapshot_date)
 primis_variables(dataset = dataset, index_date = snapshot_date)
 # other_cx_variables(dataset = dataset, index_date = snapshot_date)
+
+# Deregistration dates after the snapshot date
+dereg_date = (
+    practice_registrations
+    .where(practice_registrations.end_date.is_not_null())
+    .where(practice_registrations.end_date.is_on_or_after(snapshot_date))
+    .sort_by(practice_registrations.end_date)
+    .first_for_patient()
+    .end_date
+)
+# Add deregistration to dataset
+dataset.add_column(f"dereg_date", dereg_date)

--- a/analysis/dummydata_varying.R
+++ b/analysis/dummydata_varying.R
@@ -164,7 +164,7 @@ sim_list_varying_i <- function(i) {
   vax_variable <- glue("covid_vax_{i}_day")
 
   lst(
-    "deregistered_{i}_day" := bn_node(
+    "dereg_{i}_date" := bn_node(
       ~ as.integer(runif(n = ..n, index_day, index_day + 1200)),
       missing_rate = ~0.99,
       needs = vax_variable

--- a/analysis/process.R
+++ b/analysis/process.R
@@ -101,7 +101,7 @@ data_extract_varying <- read_feather(here("output", "extracts", "extract_varying
 # Reshape vaccination data
 data_vax <-
   data_extract_varying %>%
-  #lazy_dt() %>%
+  lazy_dt() %>%
   select(
     patient_id,
     matches("covid_vax\\_\\d+\\_date"),
@@ -144,7 +144,7 @@ data_vax <-
     vax_date = covid_vax,
     vax_type = covid_vax_type
   ) %>%
-  #as_tibble() %>% # insert this here to revert to standard dplyr as `cut` function doesn't work with dtplyr
+  as_tibble() %>% # insert this here to revert to standard dplyr as `cut` function doesn't work with dtplyr
   mutate(
     !!!standardise_characteristics,
     vax_campaign = cut(
@@ -157,7 +157,7 @@ data_vax <-
   arrange(patient_id, vax_date) %>%
   mutate(
     vax_type_raw = vax_type,
-    vax_type = fct_recode(factor(vax_type, vax_product_lookup), !!!vax_product_lookup) %>% fct_explicit_na("other")
+    vax_type = fct_recode(factor(vax_type, vax_product_lookup), !!!vax_product_lookup) %>% fct_na_value_to_level("other")
   ) %>%
   group_by(patient_id) %>%
   mutate(

--- a/analysis/process.R
+++ b/analysis/process.R
@@ -107,7 +107,7 @@ data_vax <-
     matches("covid_vax\\_\\d+\\_date"),
     matches("covid_vax_type_\\d+"),
     matches("registered_\\d+"),
-    matches("deregistration_\\d+"),
+ #   matches("deregistered_\\d+\\_date"),
     matches("age_\\d+"),
     matches("ageband_\\d+"),
     matches("region_\\d+"),
@@ -142,7 +142,7 @@ data_vax <-
   ) %>%
   rename(
     vax_date = covid_vax,
-    vax_type = covid_vax_type,
+    vax_type = covid_vax_type
   ) %>%
   #as_tibble() %>% # insert this here to revert to standard dplyr as `cut` function doesn't work with dtplyr
   mutate(

--- a/analysis/report_history.R
+++ b/analysis/report_history.R
@@ -63,7 +63,7 @@ data_vax_clean <-
   ) %>%
   as_tibble() %>%
   mutate(
-    across(where(is.factor) | where(is.character), ~fct_explicit_na(.x, na_level ="Unknown"))
+    across(where(is.factor) | where(is.character), ~fct_na_value_to_level(.x, "Unknown"))
   )
 
 

--- a/analysis/report_snapshot.R
+++ b/analysis/report_snapshot.R
@@ -177,7 +177,7 @@ data_combined %>%
     imd_quintile,
     primis_atrisk,
   ) %>%
-  write_feather(sink = fs::path(output_dir, glue("data_.arrow")))
+  write_feather(sink = fs::path(output_dir, glue("data_vax_dates.arrow")))
 
 # _______________________________________________________________________________________
 # Report vaccination info, stratifying by characteristics recorded on the "snapshot_date" ----

--- a/analysis/variables_function.py
+++ b/analysis/variables_function.py
@@ -6,7 +6,7 @@
 
 from ehrql import case, days, when, years
 
-from codelists import *
+import codelists
  
 from ehrql.tables.core import (
   medications,
@@ -78,16 +78,16 @@ def last_prior_meds(codelist, index_date, where=True):
 # Asthma
 def has_asthma(index_date):
     # Asthma diagnosis
-    has_astdx = has_prior_event(ast, index_date)
+    has_astdx = has_prior_event(codelists.ast, index_date)
     # Asthma admision
     has_asthadm = has_prior_event(
-        astadm,
+        codelists.astadm,
         index_date,
         where = clinical_events.date.is_on_or_between(index_date - years(2), index_date)
     )
     # Inhaled asthma prescription in previous year
     has_astrx_inhaled = has_prior_meds(
-        astrxm1,
+        codelists.astrxm1,
         index_date,
         where = medications.date.is_on_or_after(index_date - years(1))
     )
@@ -95,7 +95,7 @@ def has_asthma(index_date):
     prior_meds = medications.where(medications.date.is_on_or_before(index_date))
     count_astrx_oral = (
         prior_meds
-        .where(prior_meds.dmd_code.is_in(astrx))
+        .where(prior_meds.dmd_code.is_in(codelists.astrx))
         .where(prior_meds.date.is_on_or_between(index_date - years(2), index_date))
         .count_for_patient()
     )
@@ -110,11 +110,11 @@ def has_asthma(index_date):
 # Chronic Kidney Disease (CKD)
 def has_ckd(index_date):
     # Chronic kidney disease diagnostic codes
-    has_ckd_cov = has_prior_event(ckd_cov, index_date)
+    has_ckd_cov = has_prior_event(codelists.ckd_cov, index_date)
     # Chronic kidney disease codes - all stages
-    ckd15_date = last_prior_event(ckd15, index_date).date
+    ckd15_date = last_prior_event(codelists.ckd15, index_date).date
     # Chronic kidney disease codes-stages 3 - 5
-    ckd35_date = last_prior_event(ckd35, index_date).date
+    ckd35_date = last_prior_event(codelists.ckd35, index_date).date
     # Chronic kidney disease
     ckd = case(
         when(has_ckd_cov).then(True),
@@ -126,7 +126,7 @@ def has_ckd(index_date):
 
 # Chronic Respiratory Disease (CRD)
 def has_crd(index_date, where=True):
-    has_resp_cov = has_prior_event(resp_cov, index_date)
+    has_resp_cov = has_prior_event(codelists.resp_cov, index_date)
     has_crd = has_resp_cov | has_asthma(index_date)
     return has_crd
 
@@ -136,17 +136,17 @@ def has_severe_obesity(index_date):
     aged18plus = patients.age_on(index_date) >= 18
     # Last BMI stage event
     date_bmi_stage = last_prior_event(
-        bmi_stage, 
+        codelists.bmi_stage, 
         index_date
     ).date
     # Last severe obesity event
     date_sev_obesity = last_prior_event(
-        sev_obesity, 
+        codelists.sev_obesity, 
         index_date
     ).date
     # Last BMI event not null
     event_bmi = last_prior_event(
-        bmi, 
+        codelists.bmi, 
         index_date,
         where=(
             clinical_events.numeric_value.is_not_null() & 
@@ -177,19 +177,19 @@ def has_severe_obesity(index_date):
 def has_pregnancy(index_date):
     # Pregnancy delivery code date (a delivery code between 8 and 15 months prior to index date)
     pregAdel_date = last_prior_event(
-        pregdel,
+        codelists.pregdel,
         index_date,
         where=clinical_events.date.is_on_or_between(index_date - days(7 * 65), index_date - days((7 * 30) + 1))
     ).date
     # Pregnancy: 8 months and 15 months (a pregnancy code between 8 and 15 months prior to index date)
     pregA_date = last_prior_event(
-        preg,
+        codelists.preg,
         index_date,
         where=clinical_events.date.is_on_or_between(index_date - days(7 * 65), index_date - days((7 * 30) + 1))
     ).date
     # Pregnancy: <8 months (a pregnancy code within 8 months prior to index date)
     pregB = has_prior_event(
-        preg,
+        codelists.preg,
         index_date,
         where=clinical_events.date.is_on_or_between(index_date - days(7 * 30), index_date)
     )
@@ -207,11 +207,11 @@ def has_pregnancy(index_date):
 
 # Diabetes
 def has_diabetes(index_date, where=True):
-    date_diab = last_prior_event(diab, index_date).date
-    date_dmres = last_prior_event(dmres, index_date).date
-    has_gdiab = has_prior_event(gdiab, index_date)
+    date_diab = last_prior_event(codelists.diab, index_date).date
+    date_dmres = last_prior_event(codelists.dmres, index_date).date
+    has_gdiab = has_prior_event(codelists.gdiab, index_date)
     has_diab_group = has_gdiab & has_pregnancy(index_date)
-    has_addis = has_prior_event(addis, index_date)
+    has_addis = has_prior_event(codelists.addis, index_date)
     # Diabetes condition
     diabetes = case(
         when(date_dmres < date_diab).then(True),
@@ -226,24 +226,24 @@ def has_diabetes(index_date, where=True):
 def is_immunosuppressed(index_date):
     # Immunosuppression diagnosis
     has_immdx_cov = has_prior_event(
-        immdx_cov, 
+        codelists.immdx_cov, 
         index_date
     )
     # Immunosuppression medication (within the last 3 years)
     has_immrx = has_prior_meds(
-        immrx,
+        codelists.immrx,
         index_date,
         where=medications.date.is_on_or_after(index_date - years(3))
     )
     # Immunosuppression admin date (within the last 3 years)
     has_immadm = has_prior_event(
-        immadm,
+        codelists.immadm,
         index_date,
         where=clinical_events.date.is_on_or_after(index_date - years(3))
     )
     # Chemotherapy medication date (within the last 3 years)
     has_dxt_chemo = has_prior_event(
-        dxt_chemo,
+        codelists.dxt_chemo,
         index_date,
         where=clinical_events.date.is_on_or_after(index_date - years(3))
     )
@@ -259,9 +259,9 @@ def is_immunosuppressed(index_date):
 
 # Severe mental illness 
 def has_smi(index_date, where=True):
-    date_sev_mental = last_prior_event(sev_mental, index_date).date
+    date_sev_mental = last_prior_event(codelists.sev_mental, index_date).date
     # Remission codes relating to Severe Mental Illness
-    date_smhres = last_prior_event(smhres, index_date).date
+    date_smhres = last_prior_event(codelists.smhres, index_date).date
     # Severe mental illness
     smi = case(
         when(date_smhres < date_sev_mental).then(True),
@@ -282,11 +282,11 @@ def primis_atrisk(index_date):
         has_ckd(index_date) |                   # chronic kidney disease
         has_crd(index_date) |                   # chronic respiratory disease
         has_diabetes(index_date) |              # diabetes        
-        has_prior_event(cld, index_date) |      # chronic liver disease
-        has_prior_event(cns_cov, index_date) |  # chronic neurological disease
-        has_prior_event(chd_cov, index_date) |  # chronic heart disease
-        has_prior_event(spln_cov, index_date) | # asplenia or spleen dysfunction
-        has_prior_event(learndis, index_date) | # learning disability
+        has_prior_event(codelists.cld, index_date) |      # chronic liver disease
+        has_prior_event(codelists.cns_cov, index_date) |  # chronic neurological disease
+        has_prior_event(codelists.chd_cov, index_date) |  # chronic heart disease
+        has_prior_event(codelists.spln_cov, index_date) | # asplenia or spleen dysfunction
+        has_prior_event(codelists.learndis, index_date) | # learning disability
         has_smi(index_date) |                   # severe mental illness
         has_severe_obesity(index_date)          # severe obesity
     )
@@ -295,13 +295,13 @@ def primis_atrisk(index_date):
 def primis_variables(dataset, index_date, var_name_suffix=""):
     dataset.add_column(f"immunosuppressed{var_name_suffix}", is_immunosuppressed(index_date)) #immunosuppress grouped
     dataset.add_column(f"ckd{var_name_suffix}", has_ckd(index_date)) #chronic kidney disease
-    dataset.add_column(f"crd{var_name_suffix}", has_prior_event(resp_cov, index_date)) #chronic respiratory disease
+    dataset.add_column(f"crd{var_name_suffix}", has_prior_event(codelists.resp_cov, index_date)) #chronic respiratory disease
     dataset.add_column(f"diabetes{var_name_suffix}", has_diabetes(index_date)) #diabetes
-    dataset.add_column(f"cld{var_name_suffix}", has_prior_event(cld, index_date)) # chronic liver disease
-    dataset.add_column(f"chd{var_name_suffix}", has_prior_event(chd_cov, index_date)) #chronic heart disease
-    dataset.add_column(f"cns{var_name_suffix}", has_prior_event(cns_cov, index_date)) # chronic neurological disease
-    dataset.add_column(f"asplenia{var_name_suffix}", has_prior_event(spln_cov, index_date)) # asplenia or dysfunction of the Spleen
-    dataset.add_column(f"learndis{var_name_suffix}", has_prior_event(learndis, index_date)) # learning Disability
+    dataset.add_column(f"cld{var_name_suffix}", has_prior_event(codelists.cld, index_date)) # chronic liver disease
+    dataset.add_column(f"chd{var_name_suffix}", has_prior_event(codelists.chd_cov, index_date)) #chronic heart disease
+    dataset.add_column(f"cns{var_name_suffix}", has_prior_event(codelists.cns_cov, index_date)) # chronic neurological disease
+    dataset.add_column(f"asplenia{var_name_suffix}", has_prior_event(codelists.spln_cov, index_date)) # asplenia or dysfunction of the Spleen
+    dataset.add_column(f"learndis{var_name_suffix}", has_prior_event(codelists.learndis, index_date)) # learning Disability
     dataset.add_column(f"smi{var_name_suffix}", has_smi(index_date)) #severe mental illness
     dataset.add_column(f"severe_obesity{var_name_suffix}", has_severe_obesity(index_date)) # severe obesity
     dataset.add_column(f"primis_atrisk{var_name_suffix}", primis_atrisk(index_date)) # at risk 

--- a/project.yaml
+++ b/project.yaml
@@ -82,14 +82,24 @@ actions:
         png: output/report_snapshot_20210906/*.png
         txt: output/report_snapshot_20210906/*.txt
 
-  km_action_20210906:
-    run: kaplan-meier-function:v0.0.4
+  coverage_20210906_sex:
+    run: kaplan-meier-function:v0.0.16
       --df_input=output/report_snapshot_20210906/*.arrow
-      --df_output=output/km_estimates.feather
-    needs: [report_snapshot_20210906]  
+      --dir_output=output/report_snapshot_20210906/coverage/
+      --subgroups=sex
+      --origin_date=snapshot_date
+      --event_date=vax_date
+      --censor_date=censor_date
+      --min_count=10
+      --method=constant
+      --plot=TRUE
+      --contrast=FALSE
+      --filename_suffix=sex
+    needs: [report_snapshot_20210906]
     outputs:
-      highly_sensitive:
-        output: output/km_estimates/*.feather
+      moderately_sensitive:
+        png: output/report_snapshot_20210906/coverage/*.png
+        csv: output/report_snapshot_20210906/coverage/*.csv
 
  # 2022-04-01
   extract_snapshot_20220401:
@@ -168,7 +178,7 @@ actions:
         arrow: output/report_snapshot_20230911/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20230911/*.csv
-        png: output/report_snapshot_20230911/*.png    
+        png: output/report_snapshot_20230911/*.png
         txt: output/report_snapshot_20230911/*.txt
 
  # 2024-04-01
@@ -188,7 +198,7 @@ actions:
         arrow: output/report_snapshot_20240401/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20240401/*.csv
-        png: output/report_snapshot_20240401/*.png  
+        png: output/report_snapshot_20240401/*.png
         txt: output/report_snapshot_20240401/*.txt
 
  # 2024-10-03
@@ -208,5 +218,5 @@ actions:
         arrow: output/report_snapshot_20241003/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20241003/*.csv
-        png: output/report_snapshot_20241003/*.png    
+        png: output/report_snapshot_20241003/*.png
         txt: output/report_snapshot_20241003/*.txt

--- a/project.yaml
+++ b/project.yaml
@@ -22,7 +22,7 @@ actions:
         cohort: output/extracts/extract_varying.arrow
 
   process:
-    run: r:latest analysis/process.R
+    run: r:v2 analysis/process.R
     needs: [extract_fixed, extract_varying]
     outputs:
       highly_sensitive:
@@ -33,7 +33,7 @@ actions:
 
 # report vaccine history over entire observational period ---
   report_history:
-    run: r:latest analysis/report_history.R
+    run: r:v2 analysis/report_history.R
     needs: [process]
     outputs:
       moderately_sensitive:
@@ -52,7 +52,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20201208.arrow
 
   report_snapshot_20201208:
-    run: r:latest analysis/report_snapshot.R 20201208
+    run: r:v2 analysis/report_snapshot.R 20201208
     needs: [extract_snapshot_20201208, process]
     outputs:
       moderately_sensitive:
@@ -70,7 +70,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20210906.arrow
 
   report_snapshot_20210906:
-    run: r:latest analysis/report_snapshot.R 20210906
+    run: r:v2 analysis/report_snapshot.R 20210906
     needs: [extract_snapshot_20210906, process]
     outputs:
       moderately_sensitive:
@@ -88,7 +88,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20220401.arrow
 
   report_snapshot_20220401:
-    run: r:latest analysis/report_snapshot.R 20220401
+    run: r:v2 analysis/report_snapshot.R 20220401
     needs: [extract_snapshot_20220401, process]
     outputs:
       moderately_sensitive:
@@ -106,7 +106,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20220912.arrow
 
   report_snapshot_20220912:
-    run: r:latest analysis/report_snapshot.R 20220912
+    run: r:v2 analysis/report_snapshot.R 20220912
     needs: [extract_snapshot_20220912, process]
     outputs:
       moderately_sensitive:
@@ -124,7 +124,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20230403.arrow
 
   report_snapshot_20230403:
-    run: r:latest analysis/report_snapshot.R 20230403
+    run: r:v2 analysis/report_snapshot.R 20230403
     needs: [extract_snapshot_20230403, process]
     outputs:
       moderately_sensitive:
@@ -142,7 +142,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20230911.arrow
 
   report_snapshot_20230911:
-    run: r:latest analysis/report_snapshot.R 20230911
+    run: r:v2 analysis/report_snapshot.R 20230911
     needs: [extract_snapshot_20230911, process]
     outputs:
       moderately_sensitive:
@@ -160,7 +160,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20240401.arrow
 
   report_snapshot_20240401:
-    run: r:latest analysis/report_snapshot.R 20240401
+    run: r:v2 analysis/report_snapshot.R 20240401
     needs: [extract_snapshot_20240401, process]
     outputs:
       moderately_sensitive:
@@ -178,7 +178,7 @@ actions:
         cohort: output/extracts/extract_snapshot_20241003.arrow
 
   report_snapshot_20241003:
-    run: r:latest analysis/report_snapshot.R 20241003
+    run: r:v2 analysis/report_snapshot.R 20241003
     needs: [extract_snapshot_20241003, process]
     outputs:
       moderately_sensitive:

--- a/project.yaml
+++ b/project.yaml
@@ -81,6 +81,15 @@ actions:
         csv: output/report_snapshot_20210906/*.csv
         png: output/report_snapshot_20210906/*.png
         txt: output/report_snapshot_20210906/*.txt
+        
+  km_action_20210906:
+    run: r:v2 kaplan-meier-function:v0.0.4
+      --df_input=output/report_snapshot_20210906/*.arrow
+      --df_output=output/km_estimates.feather
+    needs: [report_snapshot_20210906]  
+    outputs:
+      highly_sensitive:
+        output: output/km_estimates/*.feather
 
  # 2022-04-01
   extract_snapshot_20220401:

--- a/project.yaml
+++ b/project.yaml
@@ -55,6 +55,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20201208
     needs: [extract_snapshot_20201208, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20201208/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20201208/*.csv
         png: output/report_snapshot_20201208/*.png
@@ -73,6 +75,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20210906
     needs: [extract_snapshot_20210906, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20210906/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20210906/*.csv
         png: output/report_snapshot_20210906/*.png
@@ -91,6 +95,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20220401
     needs: [extract_snapshot_20220401, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20220401/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20220401/*.csv
         png: output/report_snapshot_20220401/*.png
@@ -109,6 +115,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20220912
     needs: [extract_snapshot_20220912, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20220912/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20220912/*.csv
         png: output/report_snapshot_20220912/*.png
@@ -127,6 +135,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20230403
     needs: [extract_snapshot_20230403, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20230403/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20230403/*.csv
         png: output/report_snapshot_20230403/*.png
@@ -145,6 +155,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20230911
     needs: [extract_snapshot_20230911, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20230911/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20230911/*.csv
         png: output/report_snapshot_20230911/*.png    
@@ -163,6 +175,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20240401
     needs: [extract_snapshot_20240401, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20240401/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20240401/*.csv
         png: output/report_snapshot_20240401/*.png  
@@ -181,6 +195,8 @@ actions:
     run: r:v2 analysis/report_snapshot.R 20241003
     needs: [extract_snapshot_20241003, process]
     outputs:
+      highly_sensitive:
+        arrow: output/report_snapshot_20241003/*.arrow
       moderately_sensitive:
         csv: output/report_snapshot_20241003/*.csv
         png: output/report_snapshot_20241003/*.png    

--- a/project.yaml
+++ b/project.yaml
@@ -81,9 +81,9 @@ actions:
         csv: output/report_snapshot_20210906/*.csv
         png: output/report_snapshot_20210906/*.png
         txt: output/report_snapshot_20210906/*.txt
-        
+
   km_action_20210906:
-    run: r:v2 kaplan-meier-function:v0.0.4
+    run: kaplan-meier-function:v0.0.4
       --df_input=output/report_snapshot_20210906/*.arrow
       --df_output=output/km_estimates.feather
     needs: [report_snapshot_20210906]  

--- a/project.yaml
+++ b/project.yaml
@@ -84,21 +84,21 @@ actions:
 
   coverage_20210906_sex:
     run: kaplan-meier-function:v0.0.16
-      --df_input=output/report_snapshot_20210906/*.arrow
+      --df_input=output/report_snapshot_20210906/data_vax_dates.arrow
       --dir_output=output/report_snapshot_20210906/coverage/
       --subgroups=sex
-      --origin_date=snapshot_date
+      --origin_date=start_date
       --event_date=vax_date
       --censor_date=censor_date
       --min_count=10
       --method=constant
-      --plot=TRUE
+      --plot=FALSE
       --contrast=FALSE
-      --filename_suffix=sex
+      --filename_suffix=_sex
     needs: [report_snapshot_20210906]
     outputs:
       moderately_sensitive:
-        png: output/report_snapshot_20210906/coverage/*.png
+        #png: output/report_snapshot_20210906/coverage/*.png
         csv: output/report_snapshot_20210906/coverage/*.csv
 
  # 2022-04-01


### PR DESCRIPTION
To create the KM cohort:
- I added to the `dataset_definition_snapshot.py` the first **deregistration date** after the snapshot date
- I added to the data_combined table
  - the `death_date` and `dereg_date` to build the censor variable 
    - I can combine them on a collective censor variable if needed
  - the `start_date` (=`snapshot_date`)and end_date (= `next_campaign_date`)
- I updated the `report_snapshot` to save the `data_combined` table as `km_cohort.csv`
  - Should we drop the ID variable? 
- I didn't modify the `project.yaml` file, but we should modify the output to **highly_sensitive** since it includes the `km_cohort.csv`