### PR TITLE
Add ELD extract and compare outputs

### DIFF
--- a/analysis/1-extract/dataset_definition_varying.py
+++ b/analysis/1-extract/dataset_definition_varying.py
@@ -92,3 +92,16 @@ for i in range(1, 16+1):
 
     previous_vax_date = current_vax.date
     
+
+
+### Add event-level data extract to test equivalence of ELD extract versus patient-level extract 
+
+# all covid-19 vaccination events
+# i don't think it's possible to restrict to first 16 events (as above for patient level data)
+# so I'll do this post-extract
+dataset.add_event_table(
+    "vaccinations",
+    vax_date = covid_vaccinations.date,
+    vax_product = covid_vaccinations.product_name,
+    age = patients.age_on(covid_vaccinations.date),
+)

--- a/project.yaml
+++ b/project.yaml
@@ -15,11 +15,11 @@ actions:
 
   extract_varying:
     run: ehrql:v1 generate-dataset analysis/1-extract/dataset_definition_varying.py
-      --output output/1-extract/extract_varying.arrow
+      --output output/1-extract/extract_varying:arrow
       #--dummy-data-file analysis/1-extract/dummy-data/dummy_varying.arrow
     outputs:
       highly_sensitive:
-        cohort: output/1-extract/extract_varying.arrow
+        cohort: output/1-extract/extract_varying/*.arrow
 
   prepare:
     run: r:v2 analysis/2-prepare/prepare.R


### PR DESCRIPTION
This PR extracts an event-level dataset of covid vaccination dates, then compares this with the same data extract via patient level data

The event-level dataset needs to undergo some preparation to ensure the comparison is fair:

* Exclude vaccines where no date is recorded (though perhaps this is only possible in the dummy data)
* Exclude any repeat vaccines occurring on the same day within the same person. Since there is no timestamp, we just keep the first vaccine record in the table and discard the rest. ehrQL currently has no way to capture same-day vaccinations in standard person-level datasets
* Exclude the 17th vaccine onwards, since we only select the first 16 vaccines in the person-level dataset

After these exclusions, the event-level and person-level extracts _should_ be identical. TBC!
