### PR TITLE
Dq checks

### DIFF
--- a/analysis/0-lib/design.R
+++ b/analysis/0-lib/design.R
@@ -53,7 +53,7 @@ fct_case_when <- function(...) {
 # - start_date is when we start the observational period proper, at the start of the mass vax programme
 # - end_date is when we stopthe observation period. This may be extended as the study progresses
 study_dates <-
-  jsonlite::read_json(path = here("analysis", "0-lib", "dates.json")) %>%
+  jsonlite::read_json(path = here("analysis", "0-lib", "dates.json")) |>
   map(as.Date)
 
 # make these available in the global environment
@@ -67,17 +67,19 @@ sdc_threshold <- 100
 campaign_dates <-
   tribble(
     ~campaign,        ~start,       ~start_rounded,
+    "Pre-2020-06-01",      "1900-01-01", "1900-01-01",
     "Pre-roll-out",   as.character(firstpossiblevax_date), as.character(firstpossiblevax_date),
     "Primary series", "2020-12-08", "2020-12-01",
-    "Autumn 2021",    "2021-09-06", "2021-09-01",
-    "Spring 2022",    "2022-04-01", "2022-04-01",
-    "Autumn 2022",    "2022-09-12", "2022-09-01",
+    "Autumn 2021",    "2021-09-01", "2021-09-01",
+    "Spring 2022",    "2022-03-21", "2022-03-21",
+    "Autumn 2022",    "2022-09-01", "2022-09-01",
     "Spring 2023",    "2023-04-03", "2023-04-01",
-    "Autumn 2023",    "2023-09-11", "2023-09-01",
-    "Spring 2024",    "2024-04-01", "2023-04-01",
-    "Autumn 2024",    "2024-10-03", "2024-09-01",
-    #"Spring 2025",    "", "",
-  ) %>%
+    "Autumn 2023",    "2023-09-01", "2023-09-01",
+    "Spring 2024",    "2024-04-15", "2023-04-01",
+    "Autumn 2024",    "2024-10-01", "2024-10-01",
+    "Spring 2025",    "2025-04-01", "2025-04-01",
+    "End",            "2030-01-01", "2030-01-01"
+  ) |>
   mutate(
     across(c(start, start_rounded), as.Date)
   )

--- a/analysis/2-prepare/prepare.R
+++ b/analysis/2-prepare/prepare.R
@@ -235,10 +235,10 @@ count_product <-
   ) |>
   group_by(adult, vax_product) |>
   summarise(
-    count_total = n(),
-    count_before20200101 = sum(vax_date < as.Date("2020-01-01")),
-    count_onorafter20200101 = sum(vax_date >= as.Date("2020-01-01")),
-    count_onorafter20201201 = sum(vax_date >= as.Date("2020-12-01")),
+    count_total = round(n(), 100),
+    count_before20200101 = round(sum(vax_date < as.Date("2020-01-01")), 100),
+    count_onorafter20200101 = round(sum(vax_date >= as.Date("2020-01-01")), 100),
+    count_onorafter20201201 = round(sum(vax_date >= as.Date("2020-12-01")), 100),
   ) |>
   as_tibble()
 
@@ -253,7 +253,7 @@ count_product_campaign <-
   ) |>
   group_by(adult, campaign, vax_product) |>
   summarise(
-    count_total = n()
+    count_total = round(n(), 100)
   ) |>
   as_tibble()
 
@@ -275,10 +275,10 @@ count_products_cooccurrence <-
   products_cooccurrence |>
   group_by(vax_product) |>
   summarise(
-    count_total = n(),
-    count_before20200101 = sum(vax_date < as.Date("2020-01-01")),
-    count_onorafter20200101 = sum(vax_date >= as.Date("2020-01-01")),
-    count_onorafter20201201 = sum(vax_date >= as.Date("2020-12-01")),
+    count_total = round(n(), 100),
+    count_before20200101 = round(sum(vax_date < as.Date("2020-01-01")), 100),
+    count_onorafter20200101 = round(sum(vax_date >= as.Date("2020-01-01")), 100),
+    count_onorafter20201201 = round(sum(vax_date >= as.Date("2020-12-01")), 100),
   ) |>
   as_tibble()
 
@@ -290,10 +290,10 @@ count_products_cooccurrence_campaign <-
   products_cooccurrence |>
   group_by(vax_product, campaign) |>
   summarise(
-    count_total = n(),
-    count_before20200101 = sum(vax_date < as.Date("2020-01-01")),
-    count_onorafter20200101 = sum(vax_date >= as.Date("2020-01-01")),
-    count_onorafter20201201 = sum(vax_date >= as.Date("2020-12-01")),
+    count_total = round(n(), 100),
+    count_before20200101 = round(sum(vax_date < as.Date("2020-01-01")), 100),
+    count_onorafter20200101 = round(sum(vax_date >= as.Date("2020-01-01")), 100),
+    count_onorafter20201201 = round(sum(vax_date >= as.Date("2020-12-01")), 100),
   ) |>
   as_tibble()
 

--- a/analysis/2-prepare/prepare.R
+++ b/analysis/2-prepare/prepare.R
@@ -220,7 +220,12 @@ data_vax_ELD <-
       vax_date,
       breaks = c(campaign_dates$start, as.Date(Inf)),
       labels = campaign_dates$campaign
-    )
+    ),
+    campaign_start = cut(
+      vax_date,
+      breaks = c(campaign_dates$start, as.Date(Inf)),
+      labels = campaign_dates$start
+    ),
   ) |>
   lazy_dt()
 
@@ -239,10 +244,11 @@ count_product <-
     count_before20200101 = round(sum(vax_date < as.Date("2020-01-01")), 100),
     count_onorafter20200101 = round(sum(vax_date >= as.Date("2020-01-01")), 100),
     count_onorafter20201201 = round(sum(vax_date >= as.Date("2020-12-01")), 100),
+    first_date_onorafter20201201 = min(if_else(vax_date>=as.Date("2020-12-01"), vax_date, as.Date(NA)))
   ) |>
   as_tibble()
 
-write_csv(count_product, fs::path(output_dir, "count_product.arrow"))
+write_csv(count_product, fs::path(output_dir, "count_product.csv"))
 
 # by campaign
 
@@ -253,11 +259,12 @@ count_product_campaign <-
   ) |>
   group_by(adult, campaign, vax_product) |>
   summarise(
-    count_total = round(n(), 100)
+    count_total = round(n(), 100),
+    first_date_during_campaign = min(vax_date)
   ) |>
   as_tibble()
 
-write_csv(count_product_campaign, fs::path(output_dir, "count_product_campaign.arrow"))
+write_csv(count_product_campaign, fs::path(output_dir, "count_product_campaign.csv"))
 
 ## count product same-day co-occurrence ----
 
@@ -266,7 +273,7 @@ products_cooccurrence <-
   filter(age >=16) |>
   group_by(patient_id, vax_date, campaign) |>
   summarise(
-    vax_product = paste0(vax_product, collapse= "  -- AND -- ")
+    vax_product = paste0(vax_product, collapse= "  -- AND -- "),
   )
 
 # count overall
@@ -279,10 +286,11 @@ count_products_cooccurrence <-
     count_before20200101 = round(sum(vax_date < as.Date("2020-01-01")), 100),
     count_onorafter20200101 = round(sum(vax_date >= as.Date("2020-01-01")), 100),
     count_onorafter20201201 = round(sum(vax_date >= as.Date("2020-12-01")), 100),
+    first_date_onorafter20201201 = min(if_else(vax_date>=as.Date("2020-12-01"), vax_date, as.Date(NA)))
   ) |>
   as_tibble()
 
-write_csv(count_products_cooccurrence, fs::path(output_dir, "count_product_cooccurrence.arrow"))
+write_csv(count_products_cooccurrence, fs::path(output_dir, "count_product_cooccurrence.csv"))
 
 # count by campaign
 
@@ -294,10 +302,11 @@ count_products_cooccurrence_campaign <-
     count_before20200101 = round(sum(vax_date < as.Date("2020-01-01")), 100),
     count_onorafter20200101 = round(sum(vax_date >= as.Date("2020-01-01")), 100),
     count_onorafter20201201 = round(sum(vax_date >= as.Date("2020-12-01")), 100),
+    first_date_during_campaign = min(vax_date)
   ) |>
   as_tibble()
 
-write_csv(count_products_cooccurrence_campaign, fs::path(output_dir, "count_product_cooccurrence_campaign.arrow"))
+write_csv(count_products_cooccurrence_campaign, fs::path(output_dir, "count_product_cooccurrence_campaign.csv"))
 
 
 # Test equivalence of ELD extract ----

--- a/analysis/2-prepare/prepare.R
+++ b/analysis/2-prepare/prepare.R
@@ -205,27 +205,119 @@ capture.output(
 write_feather(data_vax_clean, fs::path(output_dir, "data_vax_clean.arrow"))
 
 
-# Test equivalence of ELD extract ----
+# extract event level data for vaccines ----
 
 data_vax_ELD0 <- read_feather(here("output", "1-extract", "extract_varying", "vaccinations.arrow"))
 
 data_vax_ELD <-
   data_vax_ELD0 |>
+  lazy_dt() |>
   arrange(patient_id, vax_date) |>
   filter(!is.na(vax_date)) |>
+  as_tibble() |>
+  mutate(
+    campaign = cut(
+      vax_date,
+      breaks = c(campaign_dates$start, as.Date(Inf)),
+      labels = campaign_dates$campaign
+    )
+  ) |>
+  lazy_dt()
+
+
+## count products ----
+
+# overall
+count_product <-
+  data_vax_ELD |>
+  mutate(
+    adult = age >= 16
+  ) |>
+  group_by(adult, vax_product) |>
+  summarise(
+    count_total = n(),
+    count_before20200101 = sum(vax_date < as.Date("2020-01-01")),
+    count_onorafter20200101 = sum(vax_date >= as.Date("2020-01-01")),
+    count_onorafter20201201 = sum(vax_date >= as.Date("2020-12-01")),
+  ) |>
+  as_tibble()
+
+write_csv(count_product, fs::path(output_dir, "count_product.arrow"))
+
+# by campaign
+
+count_product_campaign <-
+  data_vax_ELD |>
+  mutate(
+    adult = age >= 16
+  ) |>
+  group_by(adult, campaign, vax_product) |>
+  summarise(
+    count_total = n()
+  ) |>
+  as_tibble()
+
+write_csv(count_product_campaign, fs::path(output_dir, "count_product_campaign.arrow"))
+
+## count product same-day co-occurrence ----
+
+products_cooccurrence <-
+  data_vax_ELD |>
+  filter(age >=16) |>
+  group_by(patient_id, vax_date, campaign) |>
+  summarise(
+    vax_product = paste0(vax_product, collapse= "  -- AND -- ")
+  )
+
+# count overall
+
+count_products_cooccurrence <-
+  products_cooccurrence |>
+  group_by(vax_product) |>
+  summarise(
+    count_total = n(),
+    count_before20200101 = sum(vax_date < as.Date("2020-01-01")),
+    count_onorafter20200101 = sum(vax_date >= as.Date("2020-01-01")),
+    count_onorafter20201201 = sum(vax_date >= as.Date("2020-12-01")),
+  ) |>
+  as_tibble()
+
+write_csv(count_products_cooccurrence, fs::path(output_dir, "count_product_cooccurrence.arrow"))
+
+# count by campaign
+
+count_products_cooccurrence_campaign <-
+  products_cooccurrence |>
+  group_by(vax_product, campaign) |>
+  summarise(
+    count_total = n(),
+    count_before20200101 = sum(vax_date < as.Date("2020-01-01")),
+    count_onorafter20200101 = sum(vax_date >= as.Date("2020-01-01")),
+    count_onorafter20201201 = sum(vax_date >= as.Date("2020-12-01")),
+  ) |>
+  as_tibble()
+
+write_csv(count_products_cooccurrence_campaign, fs::path(output_dir, "count_product_cooccurrence_campaign.arrow"))
+
+
+# Test equivalence of ELD extract ----
+
+data_vax_ELD_filtered <-
+  data_vax_ELD |>
   filter(vax_date > as.Date("1899-01-01")) |>
   group_by(patient_id) |>
   filter((vax_date != lag(vax_date)) | row_number() == 1) |>
   mutate(vax_index = row_number()) |>
   filter(vax_index <= 16) |>
-  ungroup()
+  ungroup() |>
+  as_tibble()
 
 capture.output(
-  skimr::skim_without_charts(data_vax_ELD),
+  skimr::skim_without_charts(data_vax_ELD_filtered),
   file = fs::path(output_dir, "data_vax_ELD_skim.txt"),
   split = FALSE
 )
-write_feather(data_vax_ELD, fs::path(output_dir, "data_vax_ELD.arrow"))
+write_feather(data_vax_ELD_filtered, fs::path(output_dir, "data_vax_ELD.arrow"))
 
 data_vax_PLD <-
   data_vax |>
@@ -245,14 +337,13 @@ cat(
   "are datasets from ELD versus PLD identical after some standardisation? \n"
 )
 
-all.equal(data_vax_ELD, data_vax_PLD)
+all.equal(data_vax_ELD_filtered, data_vax_PLD)
 
 # report multiple vaccinations on the same day
 cat(
   "\n",
   "number of occassions where a person is vaccinated more than once in a day:\n",
-  data_vax_ELD0 |>
-  filter(!is.na(vax_date)) |>
+  data_vax_ELD |>
   group_by(patient_id, vax_date) |>
   summarise(n=n()) |>
   filter(n>1) |>
@@ -263,8 +354,7 @@ cat(
 cat(
   "\n",
   "number of occassions where a person is vaccinated with a null date:\n",
-  data_vax_ELD0 |>
-  filter(is.na(vax_date)) |>
+  data_vax_ELD |>
   summarise(n=n()) |>
   pull(n)
 )
@@ -274,7 +364,7 @@ cat(
 cat(
   "\n",
   "number of occassions where a person is vaccinated on or before 1899:\n",
-  data_vax_ELD0 |>
+  data_vax_ELD |>
     filter(vax_date <= as.Date("1899-01-01")) |>
     summarise(n=n()) |>
     pull(n)


### PR DESCRIPTION
this uses the event level vaccine data to count products overall and within each campaign, as well as showing which products are being recorded in the same individual on the same day.