### PR TITLE
Flu report draft

### DIFF
--- a/analysis/1-extract/codelists.py
+++ b/analysis/1-extract/codelists.py
@@ -337,3 +337,12 @@ reside = codelist_from_csv(
     column="code",
 )
 
+# flu
+flu_vac_SNOMED = codelist_from_csv(
+    "codelists/nhsd-primary-care-domain-refsets-flu_cod.csv", 
+    column="code",
+)
+flu_vac_drug = codelist_from_csv(
+    "codelists/nhs-drug-refsets-fludrug_cod.csv", 
+    column="code",
+)

--- a/analysis/1-extract/dataset_definition_varying_flu.py
+++ b/analysis/1-extract/dataset_definition_varying_flu.py
@@ -1,0 +1,99 @@
+# _________________________________________________
+# Purpose:
+# extract event level flu vaccination from vaccinations table, medicines and clinical_event
+# _________________________________________________
+
+# import libraries and functions
+
+from json import loads
+from pathlib import Path
+
+from ehrql import (
+   # case,
+    create_dataset,
+    # days,
+    # when,
+    # minimum_of,
+    # maximum_of,
+    claim_permissions
+)
+from ehrql.tables.tpp import (
+  patients,
+  practice_registrations, 
+  medications,
+  vaccinations, 
+  clinical_events, 
+#   ons_deaths,
+#   addresses,
+)
+# import codelists
+import codelists
+
+study_dates = loads(
+    Path("analysis/0-lib/study_dates.json").read_text(),
+)
+
+# Change these in ./0-lib/deisgn.R if necessary
+start_date = study_dates["start_date"]
+end_date = study_dates["end_date"]
+
+# all covid-19 vaccination events
+
+## Vaccineations table 
+flu_vaccinations_table = (
+  vaccinations
+  .where(vaccinations.target_disease.is_in(["INFLUENZA"]))
+  .sort_by(vaccinations.date)
+)
+
+## Clinical events
+flu_vaccinations_SNOMED = (clinical_events
+  .where(clinical_events.snomedct_code.is_in(codelists.flu_vac_SNOMED))
+  .sort_by(clinical_events.date)
+)
+
+# Medications
+flu_vaccinations_drug = (medications
+  .where(medications.dmd_code.is_in(codelists.flu_vac_drug))
+  .sort_by(medications.date)
+)
+
+
+# initialise dataset
+dataset = create_dataset()
+dataset.configure_dummy_data(population_size=1000)
+
+# define dataset poppulation
+dataset.define_population(
+   (flu_vaccinations_table.exists_for_patient() |
+    flu_vaccinations_SNOMED.exists_for_patient()|    
+    flu_vaccinations_drug.exists_for_patient()
+   )
+   & (patients.age_on(end_date) >= 12) # only include people who are aged 12 or over during at least one season
+)
+
+# event level permissions
+claim_permissions("event_level_data")
+
+
+# Create datasets 
+dataset.add_event_table(
+    "flu_vaccinations_table",
+    vax_date = flu_vaccinations_table.date,
+    vax_product = flu_vaccinations_table.product_name,
+    age = patients.age_on(flu_vaccinations_table.date),
+)
+
+dataset.add_event_table(
+    "flu_vaccinations_SNOMED",
+    vax_date = flu_vaccinations_SNOMED.date,
+#    vax_snomed = flu_vaccinations_SNOMED.product_name,
+    age = patients.age_on(flu_vaccinations_SNOMED.date),
+)
+
+dataset.add_event_table(
+    "flu_vaccinations_drug",
+    vax_date = flu_vaccinations_drug.date,
+#    vax_drug = flu_vaccinations_drug.product_name,
+    age = patients.age_on(flu_vaccinations_drug.date),
+)

--- a/analysis/2-prepare/flu_data_quality.R
+++ b/analysis/2-prepare/flu_data_quality.R
@@ -1,0 +1,318 @@
+# _________________________________________________
+# purpose:
+# import event-level flu vaccination data extracted by ehrql from three sources
+# (vaccination table, clinical records, and medicines records)
+# and report data quality across sources
+#
+# outputs (rounded):
+# - table 1. flu vaccinations by campaign and data source combination:
+#   - table1_flu_sources.csv
+# - dataset used to produce upset plots by campaign:
+#   - upset_plot_data.csv
+# - table 2. agreement in vaccination date across sources:
+#   - table_date_agreement.csv
+#________________________________________________
+
+# Preliminaries ----
+
+# Import libraries
+library("tidyverse")
+library("dtplyr")
+library("lubridate")
+library("arrow")
+library("here")
+library("glue")
+library("UpSetR")
+
+# Import custom functions
+source(here("analysis", "0-lib", "design.R"))
+
+# create output directory
+output_dir <- here("output", "2-prepare", "flu_data_quality")
+fs::dir_create(output_dir)
+
+# set output width for capture.output
+options(width = 200)
+
+
+# Import event-level flu vaccination data ----
+
+data_flu_table_raw  <- read_feather(here("output", "1-extract", "extract_flu", "flu_vaccinations_table.arrow"))
+data_flu_snomed_raw <- read_feather(here("output", "1-extract", "extract_flu", "flu_vaccinations_SNOMED.arrow"))
+data_flu_drug_raw   <- read_feather(here("output", "1-extract", "extract_flu", "flu_vaccinations_drug.arrow"))
+
+# For each source:
+# - remove rows where vaccination date is missing
+# - attach info about the campaign during which the vaccination was given
+# - collapse exact duplicates (where patient id, date, and product all match)
+#
+# Exact duplicates are defined at the level of:
+# - table source: patient_id + vax_date + vax_product + age
+# - drug/SNOMED sources: patient_id + vax_date + age
+
+# fucntion: add campaign label and campaign start date based on vaccination date
+add_campaign_vars <- function(data) {
+  data |>
+    mutate(
+      campaign = cut(
+        vax_date,
+        breaks = c(campaign_info$campaign_start_date, as.Date(Inf)),
+        labels = campaign_info$campaign_label
+      ),
+      campaign_start = cut(
+        vax_date,
+        breaks = c(campaign_info$campaign_start_date, as.Date(Inf)),
+        labels = campaign_info$campaign_start_date
+      ),
+      campaign = as.character(campaign),
+      campaign_start = as.Date(as.character(campaign_start))
+    )
+}
+
+# create a summary dataset for one source at person-campaign level
+summarise_source_by_campaign <- function(data, source_name) {
+  data |>
+    group_by(patient_id, campaign, campaign_start) |>
+    summarise(
+      !!paste0("n_vax_", source_name) := n(),
+      !!paste0("n_vax_including_exact_duplicates_", source_name) := sum(n),
+      !!paste0("vax_dates_", source_name, "_list") := list(sort(unique(vax_date))),
+      .groups = "drop"
+    ) |>
+    arrange(patient_id, campaign_start)
+}
+
+# process vaccinations table source ----
+
+data_flu_table <-
+  data_flu_table_raw |>
+  lazy_dt() |>
+  arrange(patient_id, vax_date) |>
+  filter(!is.na(vax_date)) |>
+  count(patient_id, vax_date, vax_product, age) |>
+  as_tibble() |>
+  add_campaign_vars()
+
+data_flu_table_summary_campaign <-
+  summarise_source_by_campaign(data_flu_table, "table")
+
+
+# process drug source ----
+
+data_flu_drug <-
+  data_flu_drug_raw |>
+  lazy_dt() |>
+  arrange(patient_id, vax_date) |>
+  filter(!is.na(vax_date)) |>
+  count(patient_id, vax_date, age) |>
+  as_tibble() |>
+  add_campaign_vars()
+
+data_flu_drug_summary_campaign <-
+  summarise_source_by_campaign(data_flu_drug, "drug")
+
+
+# process snomed source ----
+
+data_flu_snomed <-
+  data_flu_snomed_raw |>
+  lazy_dt() |>
+  arrange(patient_id, vax_date) |>
+  filter(!is.na(vax_date)) |>
+  count(patient_id, vax_date, age) |>
+  as_tibble() |>
+  add_campaign_vars()
+
+data_flu_snomed_summary_campaign <-
+  summarise_source_by_campaign(data_flu_snomed, "snomed")
+
+
+
+# Combine source summaries ----
+
+# Join person-campaign summaries across all three sources
+data_flu_summary_campaign_all <-
+  data_flu_table_summary_campaign |>
+  full_join(
+    data_flu_drug_summary_campaign,
+    by = c("patient_id", "campaign", "campaign_start")
+  ) |>
+  full_join(
+    data_flu_snomed_summary_campaign,
+    by = c("patient_id", "campaign", "campaign_start")
+  )
+
+# Functions for comparing dates across sources ----
+
+# Return TRUE if the two date vectors share at least one exact date
+has_same_day <- function(dates1, dates2) {
+  if (length(dates1) == 0 || length(dates2) == 0) return(FALSE)
+  any(dates1 %in% dates2)
+}
+
+
+# Return TRUE if any date pair across the two vectors is within n_days
+has_within_n_days <- function(dates1, dates2, n_days = 7) {
+  if (length(dates1) == 0 || length(dates2) == 0) return(FALSE)
+  any(abs(outer(dates1, dates2, "-")) <= n_days) # if memory issues rethink outer()
+}
+
+# Create dataset across sources ----
+flu_sources <-
+  data_flu_summary_campaign_all |>
+  mutate(
+    # indicators for whether the person appears in each source in a given campaign
+    in_table  = !is.na(n_vax_table)  & n_vax_table  > 0,
+    in_drug   = !is.na(n_vax_drug)   & n_vax_drug   > 0,
+    in_snomed = !is.na(n_vax_snomed) & n_vax_snomed > 0,
+
+    # mutually exclusive source combination
+    source_combination = case_when(
+      in_table & !in_drug & !in_snomed ~ "table only",
+      !in_table & in_drug & !in_snomed ~ "drug only",
+      !in_table & !in_drug & in_snomed ~ "snomed only",
+      in_table & in_drug & !in_snomed ~ "table + drug",
+      in_table & !in_drug & in_snomed ~ "table + snomed",
+      !in_table & in_drug & in_snomed ~ "drug + snomed",
+      in_table & in_drug & in_snomed ~ "table + drug + snomed"
+    ),
+
+    # agreement in vaccination dates across sources
+    same_day_table_drug =
+      map2_lgl(vax_dates_table_list, vax_dates_drug_list, has_same_day),
+
+    same_day_table_snomed =
+      map2_lgl(vax_dates_table_list, vax_dates_snomed_list, has_same_day),
+
+    within_7d_table_drug =
+      map2_lgl(vax_dates_table_list, vax_dates_drug_list, has_within_n_days),
+
+    within_7d_table_snomed =
+      map2_lgl(vax_dates_table_list, vax_dates_snomed_list, has_within_n_days)
+  )
+
+# Table 1. Source combinations by campaign ----
+  table1_flu_sources <- flu_sources |>
+  group_by(campaign, campaign_start, source_combination) |>
+  summarise(
+    n_source = round_any(n(), sdc_threshold),
+    .groups = "drop"
+  ) |>
+  group_by(campaign, campaign_start) |>
+  mutate(
+    tot_camp = sum(n_source),
+    perc_source = round(n_source / tot_camp * 100, 1),
+    n_perc_source = glue("{n_source} ({round(perc_source, 1)}%)")
+  ) |>
+  ungroup() |>
+  arrange(campaign_start, source_combination)
+
+write_csv(
+  table1_flu_sources,
+  here(output_dir, "table1_flu_sources.csv")
+)
+
+
+# Figure 1. UpSet plot: Source combinations by campaign ----
+campaigns <- unique(flu_sources$campaign)
+
+# prepare data
+upset_plot_data <- table1_flu_sources %>%
+  mutate(
+    in_table = source_combination %in% c(
+      "table only", "table + drug", "table + snomed", "table + drug + snomed"
+    ),
+    in_drug = source_combination %in% c(
+      "drug only", "table + drug", "drug + snomed", "table + drug + snomed"
+    ),
+    in_snomed = source_combination %in% c(
+      "snomed only", "table + snomed", "drug + snomed", "table + drug + snomed"
+    )
+  ) %>%
+  uncount(n_source) %>%
+  select(campaign, campaign_start, in_table, in_drug, in_snomed) %>%
+  mutate(across(c(in_table, in_drug, in_snomed), as.integer)) %>%
+  as.data.frame()
+
+write_csv(
+  upset_plot_data,
+  here(output_dir, "upset_plot_data.csv")
+)
+###############
+# run locally # -----------------------------------------------------------
+###############
+# upset_plot_data <- readr::read_csv(
+#   here("output", "2-prepare", "flu_data_quality", "upset_plot_data.csv")
+# )
+
+# loop campaigns
+# for (camp in campaigns) {
+#
+#   plot_data <- upset_plot_data %>%
+#     filter(campaign == camp) %>%
+#     select(in_table, in_drug, in_snomed) %>%
+#     as.data.frame()
+#
+#   p <- upset(
+#     plot_data,
+#     sets = c("in_table", "in_drug", "in_snomed"),
+#     sets.bar.color = "grey40",
+#     order.by = "freq",
+#     main.bar.color = "grey20",
+#     text.scale = 1.2,
+#     mainbar.y.label = paste("intersection size -", camp),
+#     sets.x.label = "people in each source"
+#   )
+#   dev.off()
+#   print(p)
+# }
+
+###############################################################
+
+# Table 2. Date agreement across sources by campaign ----
+  table_date_agreement <-
+    bind_rows(
+      flu_sources |>
+        filter(in_table, in_drug) |>
+        group_by(campaign) |>
+        summarise(
+          comparison = "Same day: Table vs Drug",
+          n = roundmid_any(sum(same_day_table_drug, na.rm = TRUE), sdc_threshold),
+          denom = roundmid_any(n(), sdc_threshold),
+          .groups = "drop"
+        ),
+      flu_sources |>
+        filter(in_table, in_snomed) |>
+        group_by(campaign) |>
+        summarise(
+          comparison = "Same day: Table vs SNOMED",
+          n = roundmid_any(sum(same_day_table_snomed, na.rm = TRUE), sdc_threshold),
+          denom = roundmid_any(n(), sdc_threshold),
+          .groups = "drop"
+        ),
+      flu_sources |>
+        filter(in_table, in_drug) |>
+        group_by(campaign) |>
+        summarise(
+          comparison = "Within 7 days: Table vs Drug",
+          n = roundmid_any(sum(within_7d_table_drug, na.rm = TRUE), sdc_threshold),
+          denom = roundmid_any(n(), sdc_threshold),
+          .groups = "drop"
+        ),
+      flu_sources |>
+        filter(in_table, in_snomed) |>
+        group_by(campaign) |>
+        summarise(
+          comparison = "Within 7 days: Table vs SNOMED",
+          n = roundmid_any(sum(within_7d_table_snomed, na.rm = TRUE), sdc_threshold),
+          denom = roundmid_any(n(), sdc_threshold),
+          .groups = "drop"
+        )
+    ) |>
+    mutate(
+      pct = 100 * n / denom,
+      n_pct = glue("{n} ({round(pct, 1)}%)")
+    ) |>
+    arrange(campaign, comparison)
+
+write_csv(table_date_agreement,here(output_dir, "table_date_agreement.csv"))

--- a/analysis/2-prepare/flu_data_quality.R
+++ b/analysis/2-prepare/flu_data_quality.R
@@ -146,15 +146,22 @@ data_flu_summary_campaign_all <-
 
 # Return TRUE if the two date vectors share at least one exact date
 has_same_day <- function(dates1, dates2) {
-  if (length(dates1) == 0 || length(dates2) == 0) return(FALSE)
-  any(dates1 %in% dates2)
+  if (length(dates1) == 0 || length(dates2) == 0) {
+    return(FALSE)
+  } else {
+    any(dates1 %in% dates2)
+  }
 }
 
 
 # Return TRUE if any date pair across the two vectors is within n_days
 has_within_n_days <- function(dates1, dates2, n_days = 7) {
-  if (length(dates1) == 0 || length(dates2) == 0) return(FALSE)
-  any(abs(outer(dates1, dates2, "-")) <= n_days) # if memory issues rethink outer()
+  if (length(dates1) == 0 || length(dates2) == 0) {
+    return(FALSE)
+  } else {
+    any(abs(outer(dates1, dates2, "-")) <= n_days) # if memory issues rethink outer()
+  }
+
 }
 
 # Create dataset across sources ----

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -317,6 +317,18 @@
       "url": "https://www.opencodelists.org/codelist/primis-covid19-vacc-uptake/reside_cod/v2.5/",
       "downloaded_at": "2026-01-07 16:52:31.359052Z",
       "sha": "906a866473bd4c99a48ddb1d86c08986d228ba38"
+    },
+    "nhsd-primary-care-domain-refsets-flu_cod.csv": {
+      "id": "nhsd-primary-care-domain-refsets/flu_cod/20250912",
+      "url": "https://www.opencodelists.org/codelist/nhsd-primary-care-domain-refsets/flu_cod/20250912/",
+      "downloaded_at": "2026-03-16 11:59:18.174984Z",
+      "sha": "fc33d0ea49931e2a2b6344a008e903738e021f31"
+    },
+    "nhs-drug-refsets-fludrug_cod.csv": {
+      "id": "nhs-drug-refsets/fludrug_cod/20250912",
+      "url": "https://www.opencodelists.org/codelist/nhs-drug-refsets/fludrug_cod/20250912/",
+      "downloaded_at": "2026-03-16 11:59:18.231179Z",
+      "sha": "2bb60a9958fe4b1cf64541e1dddc445c305effe7"
     }
   }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -116,3 +116,7 @@ nhsd-primary-care-domain-refsets/csflatrisk1_cod/20250912
 # Homeless
 primis-covid19-vacc-uptake/homeless_cod/v2.5
 primis-covid19-vacc-uptake/reside_cod/v2.5
+
+#flu vaccines
+nhsd-primary-care-domain-refsets/flu_cod/20250912
+nhs-drug-refsets/fludrug_cod/20250912

--- a/codelists/nhs-drug-refsets-fludrug_cod.csv
+++ b/codelists/nhs-drug-refsets-fludrug_cod.csv
@@ -1,0 +1,8 @@
+code,term
+27114211000001105,Fluenz Tetra vaccine nasal suspension 0.2ml unit dose (AstraZeneca UK Ltd) (AMP)
+34680411000001107,"Quadrivalent influenza vaccine (split virion, inactivated) suspension for injection 0.5ml pre-filled syringes (Sanofi) (AMP)"
+35726811000001104,Influenza Tetra MYL vaccine suspension for injection 0.5ml pre-filled syringes (Viatris UK Healthcare Ltd) (AMP)
+40085011000001101,"Cell-based quadrivalent influenza vaccine (surface antigen, inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK Ltd) (AMP)"
+40085311000001103,"Adjuvanted quadrivalent influenza vaccine (surface antigen, inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK Ltd) (AMP)"
+42893311000001106,"Quadrivalent influenza vaccine (split virion, inactivated) High-Dose suspension for injection 0.7ml pre-filled syringes (Sanofi) (AMP)"
+43208811000001106,Fluenz (trivalent) vaccine nasal suspension 0.2ml unit dose (AstraZeneca UK Ltd) (AMP)

--- a/codelists/nhsd-primary-care-domain-refsets-flu_cod.csv
+++ b/codelists/nhsd-primary-care-domain-refsets-flu_cod.csv
@@ -1,0 +1,20 @@
+code,term
+1037311000000106,First intranasal seasonal influenza vaccination given by pharmacist
+1037331000000103,Second intranasal seasonal influenza vaccination given by pharmacist
+1037351000000105,First inactivated seasonal influenza vaccination given by pharmacist
+1037371000000101,Second inactivated seasonal influenza vaccination given by pharmacist
+1066171000000108,Seasonal influenza vaccination given by midwife
+1066181000000105,First inactivated seasonal influenza vaccination given by midwife
+1066191000000107,Second inactivated seasonal influenza vaccination given by midwife
+1239861000000100,Seasonal influenza vaccination given in school
+884861000000100,Administration of first intranasal seasonal influenza vaccination
+884881000000109,Administration of second intranasal seasonal influenza vaccination
+945831000000105,First intramuscular seasonal influenza vaccination given by other healthcare provider
+955651000000100,Seasonal influenza vaccination given by other healthcare provider
+955661000000102,First intranasal seasonal influenza vaccination given by other healthcare provider
+955671000000109,Second intramuscular seasonal influenza vaccination given by other healthcare provider
+955681000000106,Second intranasal seasonal influenza vaccination given by other healthcare provider
+955691000000108,Seasonal influenza vaccination given by pharmacist
+955701000000108,Seasonal influenza vaccination given while hospital inpatient
+985151000000100,Administration of first inactivated seasonal influenza vaccination
+985171000000109,Administration of second inactivated seasonal influenza vaccination

--- a/project.yaml
+++ b/project.yaml
@@ -247,3 +247,23 @@ actions:
         csv: output/4-snapshot/report_snapshot_20250929/*.csv
         png: output/4-snapshot/report_snapshot_20250929/*.png
         txt: output/4-snapshot/report_snapshot_20250929/*.txt
+
+
+#########################
+#  Flu vax data quality #
+#########################
+
+  extract_flu:
+    run: ehrql:v1 generate-dataset analysis/1-extract/dataset_definition_varying_flu.py
+      --output output/1-extract/extract_flu:arrow
+      #--dummy-data-file analysis/1-extract/dummy-data/dummy_varying.arrow
+    outputs:
+      highly_sensitive:
+        cohort: output/1-extract/extract_flu/*.arrow
+
+  vax_flu_data_quality:
+    run: r:v2 analysis/2-prepare/flu_data_quality.R
+    needs: [extract_flu]
+    outputs:
+      moderately_sensitive:
+        csv: output/2-prepare/flu_data_quality/*.csv


### PR DESCRIPTION
I created the first draft of the flu vaccine data quality report.

A few points still need to be confirmed or adjusted:
 - I am currently using the COVID-19 vaccine campaign dates. For flu, it may be better 
    - to switch to campaign **start dates** of 1 September or 1 October, depending on the eligible group. For example, in the "Autumn/Winter 2025/26 campaign, eligibility started on 1 September 2025 for pregnant women, children aged 2 or 3, school-aged children (Reception to Year 11), and children in a clinical risk group aged 6 months to 17 years; all other cohorts became eligible on 1 October 2025".

   - We should also decide on the campaign **end date**. I suggest using 31 March.

   - Should we consider our **initial flu** campaign in 2020?

 - I am using `roundanymid()`. Is that ok?

 - There are several inconveniences when saving `UpSet` plots as `PNGs`. For now, I will extract the rounded table and create the plots locally.